### PR TITLE
Fix: Resolve int64 type issue in frame_id for FileStorage

### DIFF
--- a/include/debug.h
+++ b/include/debug.h
@@ -17,7 +17,7 @@ namespace rm::debug
         cv::VideoWriter stream_writer;
 
         int64 section_id = 0;
-        int64 frame_id = 0;
+        int frame_id = 0;
         bool reading = true;
 
     public:


### PR DESCRIPTION
Changed int64 to int for frame_id